### PR TITLE
fix(templates): incorrect `href` attribute

### DIFF
--- a/dash/templates/shared_boards_group.html
+++ b/dash/templates/shared_boards_group.html
@@ -47,8 +47,8 @@
                   </div>
                   <div class="text-dark fw-bold h5 mb-0">
                     <hr>
-                    <a href="">
-                      <button class="btn btn-primary" type="button" href="{% url 'shared' %}">Zobacz Tablice</button>
+                    <a href="{% url 'shared' %}">
+                      <button class="btn btn-primary" type="button">Zobacz Tablice</button>
                     </a>
                   </div>
                 </div>


### PR DESCRIPTION
Naprawia przycisk *Zobacz Tablice*.
Przenosi `href="{% url 'shared' %}"` z `button` do `a`.