### PR TITLE
Napraw build Dockera: przypnij pnpm do v9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update \
     && apt upgrade -y \
     && apt clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && npm i -g -f pnpm
+    && npm i -g -f pnpm@9
 
 RUN groupadd -r builder \
     && useradd --no-log-init -r -m -g builder builder \


### PR DESCRIPTION
Najnowszy pnpm (v10+) nie czyta już pola "pnpm" z package.json, przez co onlyBuiltDependencies (esbuild) był ignorowany i instalacja kończyła się błędem ERR_PNPM_IGNORED_BUILDS. Lockfile jest w formacie 9.0, więc pnpm 9 jest zgodny i respektuje onlyBuiltDependencies.