### PR TITLE
Archiwizacja i przywracanie tablic + fix builda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       # Jeśli push pochodzi z tagu, IMAGE_TAG przyjmie wartość nazwy tagu,
       # w przeciwnym przypadku zostanie ustawione na "main"


### PR DESCRIPTION
## Co robi ten PR

### Archiwizacja tablic
- Nowe pole `archived_at` na `ExcalidrawRoom` (miękkie ukrycie — dane nienaruszone, przywracanie bezstratne) + migracja `0005`.
- Metody `archive()` / `restore()` i właściwość `is_archived`.
- „Moje Tablice" i „Wspólne Tablice" pokazują tylko niezarchiwizowane.
- Nowy widok **Archiwum** (`boards/archived`): przywracanie i trwałe usuwanie.
- UI: akcja „Archiwizuj" w menu tablicy, strona archiwum, link w menu bocznym.
- Admin: kolumna/filtr `archived_at` + akcje masowe archiwizuj/przywróć.

### Fixy CI/build
- Dockerfile: przypięcie `pnpm@9` (najnowszy pnpm nie czytał `pnpm.onlyBuiltDependencies` z package.json → `ERR_PNPM_IGNORED_BUILDS`).
- `main.yml`: dodane `permissions: packages: write` (push do GHCR kończył się `denied: installation not allowed to Write organization package`).

## Uwaga
Migracja bazy po wdrożeniu: `python manage.py migrate collab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)