### PR TITLE
Fix startu kontenera: setuptools<81 (pkg_resources)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ USER builder
 COPY --chown=builder:builder ./wheels.requirements.txt .
 
 RUN mkdir -p wheels
-RUN pip install --no-cache-dir -U pip setuptools wheel
+# setuptools>=81 usunęło moduł pkg_resources, którego wymaga gunicorn==20.1.0,
+# dlatego przypinamy setuptools poniżej tej wersji.
+RUN pip install --no-cache-dir -U pip wheel 'setuptools<81'
 RUN pip wheel -r wheels.requirements.txt -w ./wheels/
 
 # --------------------- Final Stage ---------------------
@@ -52,7 +54,9 @@ FROM python:3.10-slim AS ltiapp
 WORKDIR /srv
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -U pip setuptools wheel
+# setuptools>=81 usunęło moduł pkg_resources, którego wymaga gunicorn==20.1.0,
+# dlatego przypinamy setuptools poniżej tej wersji.
+RUN pip install --no-cache-dir -U pip wheel 'setuptools<81'
 
 RUN apt update \
     && apt upgrade -y \


### PR DESCRIPTION
## Problem
Po zbudowaniu obrazu kontener wywalał się przy starcie gunicorna:
`ModuleNotFoundError: No module named 'pkg_resources'`.

`gunicorn==20.1.0` importuje `pkg_resources`, a Dockerfile robił
niepinowany `pip install -U setuptools`, przez co wchodził setuptools 84,
który usunął moduł `pkg_resources` (zniknął w 81+).

## Fix
Przypięcie `setuptools<81` w obu etapach (wheel_builder i final).

## Uwaga (osobny, kosmetyczny temat)
Ostrzeżenie „models in app 'collab' have changes not yet reflected" pochodzi
od pola `user_room_name` z `default=make_room_name(50)` (losowy string przy
każdym starcie) — to nie blokuje startu i nie dotyczy migracji archiwizacji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)