### PR TITLE
Archiwizacja grup wraz z tablicami

### DIFF
--- a/collab/admin.py
+++ b/collab/admin.py
@@ -193,6 +193,28 @@ class BoardGroupsAdmin(admin.ModelAdmin):
         'owner',
         'users',
         'users_that_can_draw',
-        'boards'
+        'boards',
+        'archived_at',
     ]
+    list_display = ['__str__', 'class_name', 'class_year', 'owner', 'archived_at']
+    list_filter = ['archived_at']
+    actions = ['archive_groups', 'restore_groups']
     filter_horizontal = ['users', 'users_that_can_draw', 'boards']
+
+    @admin.display(description=_("Archive selected groups (with their boards)"))
+    def archive_groups(self, request, queryset):
+        updated = 0
+        for group in queryset:
+            if not group.is_archived:
+                group.archive()
+                updated += 1
+        self.message_user(request, _("Archived %d group(s).") % updated, messages.SUCCESS)
+
+    @admin.display(description=_("Restore selected groups (with their boards)"))
+    def restore_groups(self, request, queryset):
+        updated = 0
+        for group in queryset:
+            if group.is_archived:
+                group.restore()
+                updated += 1
+        self.message_user(request, _("Restored %d group(s).") % updated, messages.SUCCESS)

--- a/collab/migrations/0006_boardgroups_archived_at.py
+++ b/collab/migrations/0006_boardgroups_archived_at.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('collab', '0005_excalidrawroom_archived_at'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='boardgroups',
+            name='archived_at',
+            field=models.DateTimeField(blank=True, default=None, null=True, verbose_name='data archiwizacji'),
+        ),
+    ]

--- a/collab/models.py
+++ b/collab/models.py
@@ -313,9 +313,30 @@ class BoardGroups(models.Model):
     users = models.ManyToManyField(CustomUser, related_name='users_group', blank=True)
     users_that_can_draw = models.ManyToManyField(CustomUser, related_name='drawing_users_group', blank=True)
     boards = models.ManyToManyField(ExcalidrawRoom, related_name='boards', blank=True)
+    archived_at = models.DateTimeField(_("data archiwizacji"), null=True, blank=True, default=None)
 
     def __str__(self):
         return f"{self.class_name} {self.class_year} {self.category} {self.owner}"
+
+    @property
+    def is_archived(self) -> bool:
+        return self.archived_at is not None
+
+    def archive(self):
+        """Archive the group together with all of its boards."""
+        now = timezone.now()
+        if self.archived_at is None:
+            self.archived_at = now
+            self.save(update_fields=['archived_at'])
+        # cascade to the group's boards (skip the ones already archived)
+        self.boards.filter(archived_at__isnull=True).update(archived_at=now)
+
+    def restore(self):
+        """Restore the group together with all of its boards."""
+        if self.archived_at is not None:
+            self.archived_at = None
+            self.save(update_fields=['archived_at'])
+        self.boards.filter(archived_at__isnull=False).update(archived_at=None)
 
     def save(self, *args, **kwargs):
         if not self.code:

--- a/dash/templates/archived_boards_group.html
+++ b/dash/templates/archived_boards_group.html
@@ -1,0 +1,156 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block site_name %}Archiwum Grup{% endblock %}
+
+{% block content %}
+<div id="cards" class="row" style="overflow-y: scroll;height: 70vh;">
+    {% if groups %}
+      {% for group in groups %}
+        <div class="col-md-6 col-xl-3 mb-4">
+          <div class="card shadow border-left-warning py-2">
+            <div class="card-header d-flex justify-content-between align-items-center" style="background: transparent;">
+              <span class="text-primary fw-bold m-0 text-wrap">{{ group.class_name }} {{ group.class_year }}</span>
+              <div class="dropdown no-arrow">
+                <button class="btn btn-link btn-sm dropdown-toggle" aria-expanded="false" data-bs-toggle="dropdown" type="button">
+                  <i class="fas fa-ellipsis-v text-gray-400"></i>
+                </button>
+                <div class="dropdown-menu shadow dropdown-menu-end animated--fade-in">
+                  <p class="text-center dropdown-header">Akcje</p>
+                  <a class="dropdown-item restore-group-btn" href="#"
+                     data-group-id="{{ group.group_id }}"
+                     data-group-name="{{ group.class_name }} {{ group.class_year }}"
+                     data-group-boards="{{ group.board_count }}"
+                     data-bs-toggle="modal"
+                     data-bs-target="#restoreGroupModal">
+                    Przywróć
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item delete-group-btn" href="#"
+                     data-group-id="{{ group.group_id }}"
+                     data-group-name="{{ group.class_name }} {{ group.class_year }}"
+                     data-bs-toggle="modal"
+                     data-bs-target="#deleteGroupModal">
+                    Usuń trwale
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="card-body" style="background: transparent;">
+              <div class="row g-0 align-items-center">
+                <div class="col me-2">
+                  <div class="text-uppercase text-primary fw-bold text-xs mb-1">
+                    <span class="d-lg-flex justify-content-lg-start">Tablice:&nbsp;<b>{{ group.board_count }}</b></span>
+                    <span class="d-lg-flex justify-content-lg-start">Poziom:&nbsp;<b>{{ group.category }}</b></span>
+                    <span class="d-lg-flex justify-content-lg-start">Zarchiwizowano:&nbsp;<b>{{ group.archived_at }}</b></span>
+                  </div>
+                  <div class="text-dark fw-bold h5 mb-0">
+                    <hr>
+                    <button class="btn btn-success restore-group-btn" type="button"
+                            data-group-id="{{ group.group_id }}"
+                            data-group-name="{{ group.class_name }} {{ group.class_year }}"
+                            data-group-boards="{{ group.board_count }}"
+                            data-bs-toggle="modal"
+                            data-bs-target="#restoreGroupModal">Przywróć</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    {% else %}
+      <div class="col-md-6 col-xl-3 mb-4">
+        <div class="card shadow border-left-secondary py-2">
+          <div class="card-header d-flex justify-content-between align-items-center" style="background: transparent;">
+            <span class="text-primary fw-bold m-0">Archiwum grup jest puste</span>
+          </div>
+          <div class="card-body" style="background: transparent;">
+            <div class="row g-0 align-items-center">
+              <div class="col me-2">
+                <div class="text-uppercase text-primary fw-bold text-xs mb-1">
+                  <span class="d-lg-flex justify-content-lg-start">Zarchiwizowane grupy pojawią się tutaj</span>
+                </div>
+                <div class="text-dark fw-bold h5 mb-0">
+                  <hr>
+                  <a href="{% url 'my_board_groups' %}"><button class="btn btn-primary" type="button">Moje Grupy</button></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block modals %}
+  <!-- Modal: Restore Group -->
+  <div class="modal fade" id="restoreGroupModal" tabindex="-1" aria-labelledby="restoreGroupModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="restoreGroupModalLabel">Przywracanie grupy</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+        </div>
+        <form method="POST" action="{% url 'archived_groups' %}">
+          {% csrf_token %}
+          <div class="modal-body">
+            <p>Czy na pewno chcesz przywrócić grupę <strong id="restoreModalGroupName"></strong>?</p>
+            <p class="text-muted mb-0">Razem z grupą zostanie przywróconych <strong id="restoreModalGroupBoards"></strong> jej tablic.</p>
+            <input type="hidden" name="group_id" id="restoreModalGroupId" value="">
+            <input type="hidden" name="_method" value="RESTORE">
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
+            <button type="submit" class="btn btn-success">Przywróć</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: Delete Group (permanent) -->
+  <div class="modal fade" id="deleteGroupModal" tabindex="-1" aria-labelledby="deleteGroupModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="deleteGroupModalLabel">Trwałe usunięcie grupy</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+        </div>
+        <form method="POST" action="{% url 'archived_groups' %}">
+          {% csrf_token %}
+          <div class="modal-body">
+            <p>Czy na pewno chcesz <strong>trwale usunąć</strong> grupę <strong id="modalGroupName"></strong>? Tej operacji nie można cofnąć.</p>
+            <p class="text-muted mb-0">Tablice należące do grupy nie zostaną usunięte — pozostaną w archiwum tablic.</p>
+            <input type="hidden" name="group_id" id="modalGroupId" value="">
+            <input type="hidden" name="_method" value="DELETE">
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
+            <button type="submit" class="btn btn-danger">Usuń trwale</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_script %}
+<script>
+  var restoreGroupModal = document.getElementById('restoreGroupModal');
+  restoreGroupModal.addEventListener('show.bs.modal', function (event) {
+    var button = event.relatedTarget;
+    restoreGroupModal.querySelector('#restoreModalGroupName').textContent = button.getAttribute('data-group-name');
+    restoreGroupModal.querySelector('#restoreModalGroupBoards').textContent = button.getAttribute('data-group-boards');
+    restoreGroupModal.querySelector('#restoreModalGroupId').value = button.getAttribute('data-group-id');
+  });
+
+  var deleteGroupModal = document.getElementById('deleteGroupModal');
+  deleteGroupModal.addEventListener('show.bs.modal', function (event) {
+    var button = event.relatedTarget;
+    deleteGroupModal.querySelector('#modalGroupName').textContent = button.getAttribute('data-group-name');
+    deleteGroupModal.querySelector('#modalGroupId').value = button.getAttribute('data-group-id');
+  });
+</script>
+{% endblock %}

--- a/dash/templates/base.html
+++ b/dash/templates/base.html
@@ -50,7 +50,12 @@
             <hr>
             <a class="nav-link {% if request.resolver_match.url_name == 'archived' %}active{% endif %}" href="{% url 'archived' %}" style="font-size: 0.9rem;">
               <i class="fas fa-archive"></i>
-              <span>Archiwum</span>
+              <span>Archiwum Tablic</span>
+            </a>
+            <hr>
+            <a class="nav-link {% if request.resolver_match.url_name == 'archived_groups' %}active{% endif %}" href="{% url 'archived_groups' %}" style="font-size: 0.9rem;">
+              <i class="fas fa-box-open"></i>
+              <span>Archiwum Grup</span>
             </a>
             <hr>
           {% endif %}

--- a/dash/templates/boards_group.html
+++ b/dash/templates/boards_group.html
@@ -45,6 +45,14 @@
                     Zarządzaj użytkownikami
                   </a>
                   <div class="dropdown-divider"></div>
+                  <a class="dropdown-item archive-group-btn" href="#"
+                     data-group-id="{{ group.group_id }}"
+                     data-group-name="{{ group.class_name }} {{ group.class_year }}"
+                     data-group-boards="{{ group.board_count }}"
+                     data-bs-toggle="modal"
+                     data-bs-target="#archiveGroupModal">
+                    Archiwizuj
+                  </a>
                   <a class="dropdown-item delete-group-btn" href="#"
                      data-group-id="{{ group.group_id }}"
                      data-group-name="{{ group.class_name }} {{ group.class_year }}"
@@ -155,6 +163,30 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
           <button type="submit" class="btn btn-danger">Usuń grupę</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+  <!-- Modal: Archive Group -->
+<div class="modal fade" id="archiveGroupModal" tabindex="-1" aria-labelledby="archiveGroupModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="archiveGroupModalLabel">Archiwizacja grupy</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+      </div>
+      <form method="POST" action="{% url 'my_board_groups' %}">
+        {% csrf_token %}
+        <div class="modal-body">
+          <p>Czy na pewno chcesz zarchiwizować grupę <strong id="archiveModalGroupName"></strong>?</p>
+          <p class="text-warning mb-0"><i class="fas fa-exclamation-triangle"></i> Razem z grupą zostanie zarchiwizowanych <strong id="archiveModalGroupBoards"></strong> jej tablic. Grupę wraz z tablicami można później przywrócić z archiwum.</p>
+          <input type="hidden" name="group_id" id="archiveModalGroupId" value="">
+          <input type="hidden" name="_method" value="ARCHIVE">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Anuluj</button>
+          <button type="submit" class="btn btn-warning">Archiwizuj</button>
         </div>
       </form>
     </div>
@@ -305,6 +337,16 @@
     var modalGroupId = deleteGroupModal.querySelector('#modalGroupId');
     modalGroupName.textContent = groupName;
     modalGroupId.value = groupId;
+  });
+</script>
+  <!-- JavaScript to populate the archive-group modal -->
+<script>
+  var archiveGroupModal = document.getElementById('archiveGroupModal');
+  archiveGroupModal.addEventListener('show.bs.modal', function (event) {
+    var button = event.relatedTarget;
+    archiveGroupModal.querySelector('#archiveModalGroupName').textContent = button.getAttribute('data-group-name');
+    archiveGroupModal.querySelector('#archiveModalGroupBoards').textContent = button.getAttribute('data-group-boards');
+    archiveGroupModal.querySelector('#archiveModalGroupId').value = button.getAttribute('data-group-id');
   });
 </script>
   <!-- JavaScript to populate the modal and copy the code -->

--- a/dash/urls.py
+++ b/dash/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('boards/archived', views.ArchivedBoardView.as_view(), name='archived'),
     path('boards/shared', views.shared_board, name='shared'),
     path('group', views.MyBoardGroup.as_view(), name='my_board_groups'),
+    path('group/archived', views.ArchivedBoardGroup.as_view(), name='archived_groups'),
     path('group/shared', views.SharedBoardGroup.as_view(), name='shared_board_groups'),
     path('share_board', views.share_board, name='share_board'),
     path('manage_group_boards', views.manage_group_boards, name='manage_group_boards'),

--- a/dash/views.py
+++ b/dash/views.py
@@ -231,15 +231,17 @@ class MyBoardGroup(View):
     template_name = 'boards_group.html'
 
     def get(self, request):
-        # Get all groups owned by the user and annotate with the count of boards
-        groups = BoardGroups.objects.filter(owner=request.user).annotate(board_count=Count('boards')).all()
+        # Get all non-archived groups owned by the user and annotate with the count of boards
+        groups = BoardGroups.objects.filter(
+            owner=request.user, archived_at__isnull=True).annotate(board_count=Count('boards')).all()
 
         # Annotate each group with the comma-separated list of board IDs (for modal checkbox checking)
         for group in groups:
             group.board_ids = ",".join(str(board.room_name) for board in group.boards.all())
 
-        # Get all boards created by the user
-        boards = ExcalidrawRoom.objects.filter(room_created_by=request.user).all()
+        # Get all non-archived boards created by the user
+        boards = ExcalidrawRoom.objects.filter(
+            room_created_by=request.user, archived_at__isnull=True).all()
 
         return render(request, self.template_name, {'groups': groups, 'boards': boards})
 
@@ -251,6 +253,9 @@ class MyBoardGroup(View):
 
         if request.POST.get('_method') == 'PUT':
             return self.put(request)
+
+        if request.POST.get('_method') == 'ARCHIVE':
+            return self.archive(request)
 
         class_name = request.POST.get('class_name')
         if not class_name:
@@ -295,6 +300,23 @@ class MyBoardGroup(View):
         return redirect('my_board_groups')
 
     @method_decorator(require_group_owner)
+    def archive(self, request):
+        group_id = request.POST.get('group_id')
+        if not group_id:
+            messages.error(request, _("Nie podano ID grupy."))
+            return redirect('my_board_groups')
+
+        try:
+            group = BoardGroups.objects.get(group_id=group_id, owner=request.user)
+        except BoardGroups.DoesNotExist:
+            messages.add_message(request, 35, _("Nie znaleziono grupy o podanym ID."), 'danger')
+            return redirect('my_board_groups')
+
+        group.archive()
+        messages.success(request, _("Grupa i jej tablice zostały zarchiwizowane."))
+        return redirect('my_board_groups')
+
+    @method_decorator(require_group_owner)
     def put(self, request):
         group_id = request.POST.get('group_id')
         new_class_name = request.POST.get('class_name')
@@ -318,6 +340,52 @@ class MyBoardGroup(View):
 
         messages.success(request, _("Pomyślnie zmieniono dane grupy!"))
         return redirect('my_board_groups')
+
+
+@method_decorator(is_creator_or_in_staff, name='dispatch')
+class ArchivedBoardGroup(View):
+    template_name = 'archived_boards_group.html'
+
+    def get(self, request):
+        groups = BoardGroups.objects.filter(
+            owner=request.user, archived_at__isnull=False
+        ).annotate(board_count=Count('boards')).all().order_by('-archived_at')
+        return render(request, self.template_name, {'groups': groups})
+
+    def post(self, request):
+        if request.POST.get('_method') == 'DELETE':
+            return self.delete(request)
+        return self.restore(request)
+
+    def _get_group(self, request):
+        group_id = request.POST.get('group_id')
+        if not group_id:
+            messages.error(request, _("Nie podano ID grupy."))
+            return None
+        try:
+            return BoardGroups.objects.get(group_id=group_id, owner=request.user)
+        except BoardGroups.DoesNotExist:
+            messages.add_message(request, 35, _("Nie znaleziono grupy o podanym ID."), 'danger')
+            return None
+
+    @method_decorator(require_group_owner)
+    def restore(self, request):
+        group = self._get_group(request)
+        if group is None:
+            return redirect('archived_groups')
+        group.restore()
+        messages.success(request, _("Grupa i jej tablice zostały przywrócone."))
+        return redirect('archived_groups')
+
+    @method_decorator(require_group_owner)
+    def delete(self, request):
+        group = self._get_group(request)
+        if group is None:
+            return redirect('archived_groups')
+        group.delete()
+        messages.success(request, _("Pomyślnie usunięto grupę!"))
+        return redirect('archived_groups')
+
 
 @method_decorator(login_required, name='dispatch')
 class SharedBoardGroup(View):


### PR DESCRIPTION
## Co robi

Archiwum **grup** — analogiczne do archiwum tablic. Zarchiwizowanie grupy archiwizuje też **wszystkie jej tablice**; przywrócenie grupy przywraca grupę wraz z tablicami.

- `BoardGroups.archived_at` + `archive()` / `restore()` kaskadujące na tablice grupy (przez `boards.update(...)`), migracja `0006`.
- Nowy widok **Archiwum Grup** (`group/archived`, name `archived_groups`): przywracanie i trwałe usuwanie.
- Akcja „Archiwizuj" w menu grupy (z informacją ile tablic zostanie zarchiwizowanych) + link „Archiwum Grup" w menu bocznym.
- „Moje Grupy" oraz lista tablic do przypisania pomijają zarchiwizowane.
- Admin: kolumna/filtr `archived_at` na `BoardGroups` + akcje masowe archiwizuj/przywróć (z tablicami).

## Zachowanie / uwagi
- Trwałe usunięcie grupy z archiwum **nie usuwa** jej tablic — zostają w Archiwum Tablic (spójne z dotychczasowym `group.delete()`).
- Tablica bywa w wielu grupach (M2M). Archiwizacja grupy archiwizuje jej tablice globalnie; przywrócenie grupy przywraca wszystkie jej aktualnie zarchiwizowane tablice.
- Wymaga migracji: `python manage.py migrate collab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)